### PR TITLE
Fix search component class name typo

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -4,7 +4,7 @@ export function Search() {
       <input
         type="text"
         placeholder="Search"
-        class="w-[700px] border border-green-600 h-12 rounded-full bg-gray-200 text-center text-green-900 placeholder-green-900"
+        className="w-[700px] border border-green-600 h-12 rounded-full bg-gray-200 text-center text-green-900 placeholder-green-900"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- fix incorrect `class` attribute in `Search.jsx`

## Testing
- `npm run lint` *(fails: ConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_6843823a728c832da04f2d4cb0f8fd90